### PR TITLE
Call Anthropic, Cohere, Azure, TogetherAI, Replicate, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
+# Call Anthropic, Cohere, Azure, TogetherAI, Replicate, etc. 
+Call 100+ LLM APIs without changing Chat-UI's code. 
+
+Steps: 
+1. Create an OpenAI-compatible server to handle LLM API calling.
+
+We can use [LiteLLM's](https://github.com/BerriAI/litellm) Docker image to spin up an OpenAI Proxy Server
+
+```
+git clone https://github.com/BerriAI/litellm.git
+```
+
+Add your API keys / LLM configs to template_secrets.toml.
+```
+[keys]
+OPENAI_API_KEY="sk-..."
+COHERE_API_KEY="Wa-..."
+```
+[All Configs](https://github.com/BerriAI/litellm/blob/main/secrets_template.toml)
+
+Run Docker image:
+```
+docker build -t litellm . && docker run -p 8000:8000 litellm
+
+## INFO: OpenAI Proxy server running on http://0.0.0.0:8000
+```
+
+
+2. Point Chatbot-UI to the server 
+Set API Key + Base in `.env`:
+```
+OPENAI_API_KEY="my-fake-key"
+OPENAI_API_HOST="http://0.0.0.0:8000
+```
+
+
 # Chatbot UI
 
 Chatbot UI is an open source chat UI for AI models.

--- a/pages/api/google.ts
+++ b/pages/api/google.ts
@@ -112,7 +112,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<any>) => {
 
     const answerMessage: Message = { role: 'user', content: answerPrompt };
 
-    const answerRes = await fetch(`${OPENAI_API_HOST}/v1/chat/completions`, {
+    const answerRes = await fetch(`${OPENAI_API_HOST}/chat/completions`, {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`,

--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -12,7 +12,7 @@ const handler = async (req: Request): Promise<Response> => {
       key: string;
     };
 
-    let url = `${OPENAI_API_HOST}/v1/models`;
+    let url = `${OPENAI_API_HOST}/models`;
     if (OPENAI_API_TYPE === 'azure') {
       url = `${OPENAI_API_HOST}/openai/deployments?api-version=${OPENAI_API_VERSION}`;
     }

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -8,10 +8,11 @@ export interface OpenAIModel {
 }
 
 export enum OpenAIModelID {
-  GPT_3_5 = 'gpt-3.5-turbo',
-  GPT_3_5_AZ = 'gpt-35-turbo',
-  GPT_4 = 'gpt-4',
-  GPT_4_32K = 'gpt-4-32k',
+  GPT_3_5 = "gpt-3.5-turbo",
+  GPT_3_5_16K = "gpt-3.5-turbo-16k",
+  GPT_3_5_AZ = "gpt-35-turbo",
+  GPT_4 = "gpt-4",
+  GPT_4_32K = "gpt-4-32k",
 }
 
 // in case the `DEFAULT_MODEL` environment variable is not set or set to an unsupported model
@@ -20,25 +21,31 @@ export const fallbackModelID = OpenAIModelID.GPT_3_5;
 export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   [OpenAIModelID.GPT_3_5]: {
     id: OpenAIModelID.GPT_3_5,
-    name: 'GPT-3.5',
+    name: "GPT-3.5",
     maxLength: 12000,
     tokenLimit: 4000,
   },
+  [OpenAIModelID.GPT_3_5_16K]: {
+    id: OpenAIModelID.GPT_3_5_16K,
+    name: "GPT-3.5-16K",
+    maxLength: 48000,
+    tokenLimit: 16000,
+  },
   [OpenAIModelID.GPT_3_5_AZ]: {
     id: OpenAIModelID.GPT_3_5_AZ,
-    name: 'GPT-3.5',
+    name: "GPT-3.5",
     maxLength: 12000,
     tokenLimit: 4000,
   },
   [OpenAIModelID.GPT_4]: {
     id: OpenAIModelID.GPT_4,
-    name: 'GPT-4',
+    name: "GPT-4",
     maxLength: 24000,
     tokenLimit: 8000,
   },
   [OpenAIModelID.GPT_4_32K]: {
     id: OpenAIModelID.GPT_4_32K,
-    name: 'GPT-4-32K',
+    name: "GPT-4-32K",
     maxLength: 96000,
     tokenLimit: 32000,
   },

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -30,7 +30,7 @@ export const OpenAIStream = async (
   key: string,
   messages: Message[],
 ) => {
-  let url = `${OPENAI_API_HOST}/v1/chat/completions`;
+  let url = `${OPENAI_API_HOST}/chat/completions`;
   if (OPENAI_API_TYPE === 'azure') {
     url = `${OPENAI_API_HOST}/openai/deployments/${AZURE_DEPLOYMENT_ID}/chat/completions?api-version=${OPENAI_API_VERSION}`;
   }


### PR DESCRIPTION
Hey @xingkaixin,

I saw you're using Mckay's Chatbot-UI. I'm working on LiteLLM (a package to call 100+ LLM APIs - https://github.com/BerriAI/litellm) and wanted to be helpful.

Noticed you're maintaining your own fork -https://github.com/mrcashcash/chatbot-ui/commit/9cfb7388c559f9d257423fe18d3f6900bd5b6af5

This PR adds support for calling all LiteLLM supported models (Anthropic, Bedrock, Cohere, Huggingface, TogetherAI, etc.) without changing Chatbot-UI's code, by:

1. Creating an OpenAI-compatible server to handle LLM API calling. (via LiteLLM's docker image)

2. Pointing Chatbot-UI to it. (Setting API Base)

Let me know if this helps! Any feedback would be great.